### PR TITLE
updated build script, and reduced number of holograph shader material to one instance

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -20,12 +20,6 @@ body {
   font-family: Arial, Helvetica, sans-serif;
 }
 
-@layer utilities {
-  .text-balance {
-    text-wrap: balance;
-  }
-}
-
 .icon-text-shadow {
   text-shadow: 2px 2px 4px rgba(0, 0, 0, 1);
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,6 @@
 import { Suspense } from "react";
 import { default as Experience } from "@/components/mainPageComponents/Experience";
 import { Canvas } from "@react-three/fiber";
-import Loading from "../components/providers/Loading";
 
 const Main = () => {
   return (
@@ -10,7 +9,7 @@ const Main = () => {
       <script src="https://open.spotify.com/embed/iframe-api/v1" async></script>
       <div className="flex animate-fadeInOnce flex-col">
         <div className="h-[75vh] w-full md:h-[90vh]">
-          <Suspense fallback={<Loading />}>
+          <Suspense fallback={null}>
             <Canvas
               shadows
               camera={{

--- a/components/mainPageComponents/Experience.tsx
+++ b/components/mainPageComponents/Experience.tsx
@@ -1,30 +1,60 @@
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 import { Laptop, NodeIcon, ReactIcon } from ".";
-import { Color } from "three";
 import { ContactShadows, Environment, Float } from "@react-three/drei";
 import * as THREE from "three";
 import gsap from "gsap";
+import { useFrame } from "@react-three/fiber";
+import { useGSAP } from "@gsap/react";
+import vertexShader from "./shaders/holographic/vertex.glsl";
+import fragmentShader from "./shaders/holographic/fragment.glsl";
+import random2D from "./shaders/includes/random2D.glsl";
+import { useDarkMode } from "../providers/DarkModeProvider";
 
 const Experience = () => {
-  const background = useRef<Color>(null);
+  const { darkMode } = useDarkMode();
   const iconContainer = useRef<THREE.Group>(null);
 
-  useEffect(() => {
+  const lightColor = new THREE.Color(0xea580c);
+  const darkColor = new THREE.Color(0x22d3ee);
+  const color = darkMode ? darkColor : lightColor;
+
+  const processedVertexShader = vertexShader.replace(
+    "#include ../includes/random2D",
+    random2D,
+  );
+
+  const holographicMaterial = new THREE.ShaderMaterial({
+    vertexShader: processedVertexShader,
+    fragmentShader: fragmentShader,
+    uniforms: {
+      uTime: new THREE.Uniform(0),
+      uColor: new THREE.Uniform(color),
+    },
+    side: THREE.DoubleSide,
+    blending: THREE.AdditiveBlending,
+  });
+
+  useFrame(({ clock }) => {
+    const elapsedTime = clock.getElapsedTime();
+    holographicMaterial.uniforms.uTime.value = elapsedTime * 0.75;
+  });
+
+  useGSAP(() => {
     gsap.to(iconContainer.current!.position, {
       y: 0,
       duration: 1,
       delay: 2,
       ease: "sine.out",
     });
-  }, []);
+  });
 
   return (
     <>
       <Environment preset="city" />
-      <color ref={background} attach="background" args={["#1d1f2a"]} />
+      <color attach="background" args={["#1d1f2a"]} />
       <group ref={iconContainer} position={[0, -10, 0]}>
-        <ReactIcon />
-        <NodeIcon />
+        <ReactIcon holographicMaterial={holographicMaterial} />
+        <NodeIcon holographicMaterial={holographicMaterial} />
       </group>
       <Float rotationIntensity={0.4}>
         <Laptop />

--- a/components/mainPageComponents/NodeIcon.tsx
+++ b/components/mainPageComponents/NodeIcon.tsx
@@ -2,41 +2,20 @@ import React from "react";
 import { useFrame } from "@react-three/fiber";
 import { useGLTF } from "@react-three/drei";
 import * as THREE from "three";
-import { useDarkMode } from "../providers/DarkModeProvider";
-import vertexShader from "./shaders/holographic/vertex.glsl";
-import fragmentShader from "./shaders/holographic/fragment.glsl";
-import random2D from "./shaders/includes/random2D.glsl";
 
-const NodeIcon = () => {
+type Props = {
+  holographicMaterial: THREE.ShaderMaterial;
+};
+
+const NodeIcon = ({ holographicMaterial }: Props) => {
   const icon = React.useRef<THREE.Group>(null);
-  const { darkMode } = useDarkMode();
+
   const { nodes } = useGLTF(
     "https://vazxmixjsiawhamofees.supabase.co/storage/v1/object/public/models/node/model.gltf",
   );
 
-  const lightColor = new THREE.Color(0xea580c);
-  const darkColor = new THREE.Color(0x22d3ee);
-  const color = darkMode ? darkColor : lightColor;
-
-  const processedVertexShader = vertexShader.replace(
-    "#include ../includes/random2D",
-    random2D,
-  );
-
-  const holographicMaterial = new THREE.ShaderMaterial({
-    vertexShader: processedVertexShader,
-    fragmentShader: fragmentShader,
-    uniforms: {
-      uTime: new THREE.Uniform(0),
-      uColor: new THREE.Uniform(color),
-    },
-    side: THREE.DoubleSide,
-    blending: THREE.AdditiveBlending,
-  });
-
   useFrame(({ clock }) => {
     const elapsedTime = clock.getElapsedTime();
-    holographicMaterial.uniforms.uTime.value = elapsedTime * 0.75;
 
     const amplitude = Math.PI / 5;
     const frequency = 0.5;

--- a/components/mainPageComponents/ReactIcon.tsx
+++ b/components/mainPageComponents/ReactIcon.tsx
@@ -2,44 +2,22 @@ import React, { useRef } from "react";
 import { useFrame } from "@react-three/fiber";
 import { useGLTF } from "@react-three/drei";
 import * as THREE from "three";
-import { useDarkMode } from "../providers/DarkModeProvider";
-import vertexShader from "./shaders/holographic/vertex.glsl";
-import fragmentShader from "./shaders/holographic/fragment.glsl";
-import random2D from "./shaders/includes/random2D.glsl";
 
-const ReactIcon = () => {
+type Props = {
+  holographicMaterial: THREE.ShaderMaterial;
+};
+
+const ReactIcon = ({ holographicMaterial }: Props) => {
   const icon = useRef<THREE.Group>(null);
-  const { darkMode } = useDarkMode();
   const { nodes } = useGLTF(
     "https://vazxmixjsiawhamofees.supabase.co/storage/v1/object/public/models/react-logo/model.gltf",
   );
 
-  const processedVertexShader = vertexShader.replace(
-    "#include ../includes/random2D",
-    random2D,
-  );
-
-  const lightColor = new THREE.Color(0xea580c);
-  const darkColor = new THREE.Color(0x22d3ee);
-  const color = darkMode ? darkColor : lightColor;
-
-  const holographicMaterial = new THREE.ShaderMaterial({
-    vertexShader: processedVertexShader,
-    fragmentShader: fragmentShader,
-    uniforms: {
-      uTime: new THREE.Uniform(0),
-      uColor: new THREE.Uniform(color),
-    },
-    side: THREE.DoubleSide,
-    blending: THREE.AdditiveBlending,
-  });
-
   useFrame(({ clock }) => {
     const elapsedTime = clock.getElapsedTime();
-    holographicMaterial.uniforms.uTime.value = elapsedTime * 0.75;
-
     const amplitude = Math.PI / 5;
     const frequency = 0.5;
+
     icon.current!.rotation.y = Math.sin(elapsedTime * frequency) * amplitude;
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "portfolio",
       "version": "1.0.0",
       "dependencies": {
+        "@gsap/react": "^2.1.2",
         "@prisma/client": "^6.10.1",
         "@react-three/drei": "^9.122.0",
         "@react-three/fiber": "^8.18.0",
@@ -628,6 +629,16 @@
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@gsap/react": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@gsap/react/-/react-2.1.2.tgz",
+      "integrity": "sha512-JqliybO1837UcgH2hVOM4VO+38APk3ECNrsuSM4MuXp+rbf+/2IG2K1YJiqfTcXQHH7XlA0m3ykniFYstfq0Iw==",
+      "license": "SEE LICENSE AT https://gsap.com/standard-license",
+      "peerDependencies": {
+        "gsap": "^3.12.5",
+        "react": ">=17"
       }
     },
     "node_modules/@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "next dev",
-    "build": "prisma generate && next build",
+    "build": "prisma generate --no-engine && next build",
     "start": "next start",
     "lint": "next lint",
     "seed": "tsx ./db/seed",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "schema": "./db/prisma/schema.prisma"
   },
   "dependencies": {
+    "@gsap/react": "^2.1.2",
     "@prisma/client": "^6.10.1",
     "@react-three/drei": "^9.122.0",
     "@react-three/fiber": "^8.18.0",


### PR DESCRIPTION
This pull request introduces several updates, primarily focused on improving the rendering of 3D components, optimizing the fallback behavior for `Suspense`, and cleaning up unused code. Additionally, it includes a minor update to the build process and adds a new dependency for GSAP integration. Below are the most significant changes grouped by theme:

### 3D Rendering Enhancements:
* Refactored `ReactIcon` and `NodeIcon` components to accept a reusable `holographicMaterial` as a prop, reducing redundant shader initialization logic and improving maintainability (`components/mainPageComponents/ReactIcon.tsx`, `components/mainPageComponents/NodeIcon.tsx`). [[1]](diffhunk://#diff-7d8a0448ec92df8f9667e82c907cb0cf20722fd0310dd06c31bf8b8fb6bb886eL5-R20) [[2]](diffhunk://#diff-37c67a944b1d1d89f91b8dcc08e788ff1debfa70cd61e0ba09f6d157c00179b0L5-L39)
* Updated the `Experience` component to dynamically generate the `holographicMaterial` based on the current dark mode state and pass it to child components. Added custom shaders and GSAP animations for enhanced visual effects (`components/mainPageComponents/Experience.tsx`).

### Code Cleanup:
* Removed unused `Loading` component as the fallback for `Suspense` and replaced it with `null` for simplicity (`app/page.tsx`).
* Deleted the `@layer utilities` block and the `.text-balance` utility from `globals.css` since it was no longer in use (`app/globals.css`).

### Build Process and Dependencies:
* Updated the `build` script in `package.json` to include the `--no-engine` flag for `prisma generate`, optimizing the build process (`package.json`).
* Added the `@gsap/react` library to `dependencies` for GSAP integration in animations (`package.json`).